### PR TITLE
Update for newer CxxWrap version

### DIFF
--- a/deps/src/eigen_wrapper/CMakeLists.txt
+++ b/deps/src/eigen_wrapper/CMakeLists.txt
@@ -7,12 +7,12 @@ set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib;${CxxWrap_DIR}/../")
 list(APPEND CMAKE_CXX_FLAGS "-std=c++11 -march=native")
 add_definitions(-DJULIA_ENABLE_THREADING)
 
-find_package(CxxWrap)
+find_package(JlCxx)
 
 include_directories("${CMAKE_CURRENT_BINARY_DIR}/../../src/eigen/include/eigen3")
 
 add_library(eigen_wrapper SHARED wrap_eigen.cpp)
-target_link_libraries(eigen_wrapper CxxWrap::cxx_wrap)
+target_link_libraries(eigen_wrapper JlCxx::jlcxx ${Julia_LIBRARY})
 target_compile_features(eigen_wrapper PRIVATE cxx_generic_lambdas)
 
 install(TARGETS

--- a/deps/src/eigen_wrapper/wrap_eigen.cpp
+++ b/deps/src/eigen_wrapper/wrap_eigen.cpp
@@ -1,7 +1,7 @@
-#include <cxx_wrap.hpp>
+#include <jlcxx/jlcxx.hpp>
 #include <Eigen/Dense>
 
-namespace cxx_wrap
+namespace jlcxx
 {
   // Match the Eigen Matrix type, skipping the default parameters
   template<typename ScalarT, int Rows, int Cols>
@@ -13,7 +13,7 @@ namespace cxx_wrap
 }
 
 JULIA_CPP_MODULE_BEGIN(registry)
-  using namespace cxx_wrap;
+  using namespace jlcxx;
 
   Module& types = registry.create_module("EigenCpp");
 


### PR DESCRIPTION
The name of the CMake targets, namespace and header file has changed. This updates them to work with the current version of CxxWrap. See #1 